### PR TITLE
Use a non-primary key in batches

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -33,11 +33,12 @@ module ActiveRecord
     #
     # ==== Options
     # * <tt>:batch_size</tt> - Specifies the size of the batch. Defaults to 1000.
-    # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
-    # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
+    # * <tt>:start</tt> - Specifies the iteration key value to start from, inclusive of the value.
+    # * <tt>:finish</tt> - Specifies the iteration key value to end at, inclusive of the value.
     # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
     #   an order is present in the relation.
-    # * <tt>:order</tt> - Specifies the primary key order (can be :asc or :desc). Defaults to :asc.
+    # * <tt>:order</tt> - Specifies the iteration key order (can be :asc or :desc). Defaults to :asc.
+    # * <tt>:by</tt> - Specifies the iteration key. Defaults to the primary key.
     #
     # Limits are honored, and if present there is no requirement for the batch
     # size: it can be less than, equal to, or greater than the limit.
@@ -59,21 +60,21 @@ module ActiveRecord
     #   end
     #
     # NOTE: Order can be ascending (:asc) or descending (:desc). It is automatically set to
-    # ascending on the primary key ("id ASC").
-    # This also means that this method only works when the primary key is
+    # ascending on the iteration key (ie "id ASC").
+    # This also means that this method only works when the iteration key is
     # orderable (e.g. an integer or string).
     #
     # NOTE: By its nature, batch processing is subject to race conditions if
     # other processes are modifying the database.
-    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc)
+    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, by: primary_key)
       if block_given?
-        find_in_batches(start: start, finish: finish, batch_size: batch_size, error_on_ignore: error_on_ignore, order: order) do |records|
+        find_in_batches(start: start, finish: finish, batch_size: batch_size, error_on_ignore: error_on_ignore, order: order, by: by) do |records|
           records.each { |record| yield record }
         end
       else
-        enum_for(:find_each, start: start, finish: finish, batch_size: batch_size, error_on_ignore: error_on_ignore, order: order) do
+        enum_for(:find_each, start: start, finish: finish, batch_size: batch_size, error_on_ignore: error_on_ignore, order: order, by: by) do
           relation = self
-          apply_limits(relation, start, finish, order).size
+          apply_limits(relation, by, start, finish, order).size
         end
       end
     end
@@ -98,11 +99,12 @@ module ActiveRecord
     #
     # ==== Options
     # * <tt>:batch_size</tt> - Specifies the size of the batch. Defaults to 1000.
-    # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
-    # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
+    # * <tt>:start</tt> - Specifies the iteration key value to start from, inclusive of the value.
+    # * <tt>:finish</tt> - Specifies the iteration key value to end at, inclusive of the value.
     # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
     #   an order is present in the relation.
-    # * <tt>:order</tt> - Specifies the primary key order (can be :asc or :desc). Defaults to :asc.
+    # * <tt>:order</tt> - Specifies the iteration key order (can be :asc or :desc). Defaults to :asc.
+    # * <tt>:by</tt> - Specifies the iteration key. Defaults to the primary key.
     #
     # Limits are honored, and if present there is no requirement for the batch
     # size: it can be less than, equal to, or greater than the limit.
@@ -119,22 +121,22 @@ module ActiveRecord
     #   end
     #
     # NOTE: Order can be ascending (:asc) or descending (:desc). It is automatically set to
-    # ascending on the primary key ("id ASC").
-    # This also means that this method only works when the primary key is
+    # ascending on the iteration key (ie "id ASC").
+    # This also means that this method only works when the iteration key is
     # orderable (e.g. an integer or string).
     #
     # NOTE: By its nature, batch processing is subject to race conditions if
     # other processes are modifying the database.
-    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc)
+    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, by: primary_key)
       relation = self
       unless block_given?
-        return to_enum(:find_in_batches, start: start, finish: finish, batch_size: batch_size, error_on_ignore: error_on_ignore, order: order) do
-          total = apply_limits(relation, start, finish, order).size
+        return to_enum(:find_in_batches, start: start, finish: finish, batch_size: batch_size, error_on_ignore: error_on_ignore, order: order, by: by) do
+          total = apply_limits(relation, by, start, finish, order).size
           (total - 1).div(batch_size) + 1
         end
       end
 
-      in_batches(of: batch_size, start: start, finish: finish, load: true, error_on_ignore: error_on_ignore, order: order) do |batch|
+      in_batches(of: batch_size, start: start, finish: finish, load: true, error_on_ignore: error_on_ignore, order: order, by: by) do |batch|
         yield batch.to_a
       end
     end
@@ -163,11 +165,12 @@ module ActiveRecord
     # ==== Options
     # * <tt>:of</tt> - Specifies the size of the batch. Defaults to 1000.
     # * <tt>:load</tt> - Specifies if the relation should be loaded. Defaults to false.
-    # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
-    # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
+    # * <tt>:start</tt> - Specifies the iteration key value to start from, inclusive of the value.
+    # * <tt>:finish</tt> - Specifies the iteration key value to end at, inclusive of the value.
     # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
     #   an order is present in the relation.
-    # * <tt>:order</tt> - Specifies the primary key order (can be :asc or :desc). Defaults to :asc.
+    # * <tt>:order</tt> - Specifies the iteration key order (can be :asc or :desc). Defaults to :asc.
+    # * <tt>:by</tt> - Specifies the iteration key. Defaults to the primary key.
     #
     # Limits are honored, and if present there is no requirement for the batch
     # size, it can be less than, equal, or greater than the limit.
@@ -195,21 +198,24 @@ module ActiveRecord
     #   Person.in_batches.each_record(&:party_all_night!)
     #
     # NOTE: Order can be ascending (:asc) or descending (:desc). It is automatically set to
-    # ascending on the primary key ("id ASC").
-    # This also means that this method only works when the primary key is
+    # ascending on the iteration key ("id ASC").
+    # This also means that this method only works when the iteration key is
     # orderable (e.g. an integer or string).
     #
     # NOTE: By its nature, batch processing is subject to race conditions if
     # other processes are modifying the database.
-    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc)
+    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, by: primary_key)
       relation = self
       unless block_given?
-        return BatchEnumerator.new(of: of, start: start, finish: finish, relation: self)
+        return BatchEnumerator.new(of: of, start: start, finish: finish, by: by, relation: self)
       end
 
       unless [:asc, :desc].include?(order)
         raise ArgumentError, ":order must be :asc or :desc, got #{order.inspect}"
       end
+
+      key = by
+      raise ArgumentError, ":by must be present" unless key.present?
 
       if arel.orders.present?
         act_on_ignored_order(error_on_ignore)
@@ -221,45 +227,45 @@ module ActiveRecord
         batch_limit = remaining if remaining < batch_limit
       end
 
-      limit_relation = relation.reorder(batch_order(order)).limit(batch_limit)
-      limit_relation = apply_finish_limit(limit_relation, finish, order) if finish
+      limit_relation = relation.reorder(batch_order(order, key)).limit(batch_limit)
+      limit_relation = apply_finish_limit(limit_relation, key, finish, order) if finish
       limit_relation.skip_query_cache! # Retaining the results in the query cache would undermine the point of batching
 
       offset = nil
       loop do
         batch_relation = limit_relation
         if offset
-          batch_relation = apply_offset_limit(batch_relation, offset, order)
+          batch_relation = apply_offset_limit(batch_relation, key, offset, order)
         elsif start
-          batch_relation = apply_start_limit(batch_relation, start, order)
+          batch_relation = apply_start_limit(batch_relation, key, start, order)
         end
 
-        ids = if load
-          batch_relation.records.map(&:id)
+        values = if load
+          batch_relation.records.map { |record| record.public_send(key) }
         else
-          batch_relation.pluck(primary_key)
+          batch_relation.pluck(key)
         end
 
-        break if ids.empty?
+        break if values.empty?
 
         yielded_relation = relation
         if offset
-          yielded_relation = apply_offset_limit(yielded_relation, offset, order)
+          yielded_relation = apply_offset_limit(yielded_relation, key, offset, order)
         elsif start
-          yielded_relation = apply_start_limit(yielded_relation, start, order)
+          yielded_relation = apply_start_limit(yielded_relation, key, start, order)
         end
 
-        offset = ids.last
-        raise ArgumentError.new("Primary key not included in the custom select clause") unless offset
+        offset = values.last
+        raise ArgumentError.new("Iteration key not included in the custom select clause") unless offset
 
-        yielded_relation = apply_finish_limit(yielded_relation, offset, order)
+        yielded_relation = apply_finish_limit(yielded_relation, key, offset, order)
         yielded_relation.load_records(batch_relation.records) if load
         yield yielded_relation
 
-        break if ids.length < batch_limit
+        break if values.length < batch_limit
 
         if limit_value
-          remaining -= ids.length
+          remaining -= values.length
 
           if remaining == 0
             # Saves a useless iteration when the limit is a multiple of the
@@ -273,26 +279,26 @@ module ActiveRecord
     end
 
     private
-      def apply_limits(relation, start, finish, order)
-        relation = apply_start_limit(relation, start, order) if start
-        relation = apply_finish_limit(relation, finish, order) if finish
+      def apply_limits(relation, key, start, finish, order)
+        relation = apply_start_limit(relation, key, start, order) if start
+        relation = apply_finish_limit(relation, key, finish, order) if finish
         relation
       end
 
-      def apply_start_limit(relation, start, order)
-        relation.where(predicate_builder[primary_key, start, order == :desc ? :lteq : :gteq])
+      def apply_start_limit(relation, key, start, order)
+        relation.where(predicate_builder[key, start, order == :desc ? :lteq : :gteq])
       end
 
-      def apply_finish_limit(relation, finish, order)
-        relation.where(predicate_builder[primary_key, finish, order == :desc ? :gteq : :lteq])
+      def apply_finish_limit(relation, key, finish, order)
+        relation.where(predicate_builder[key, finish, order == :desc ? :gteq : :lteq])
       end
 
-      def apply_offset_limit(relation, start, order)
-        relation.where(predicate_builder[primary_key, start, order == :desc ? :lt : :gt])
+      def apply_offset_limit(relation, key, start, order)
+        relation.where(predicate_builder[key, start, order == :desc ? :lt : :gt])
       end
 
-      def batch_order(order)
-        table[primary_key].public_send(order)
+      def batch_order(order, key)
+        table[key].public_send(order)
       end
 
       def act_on_ignored_order(error_on_ignore)

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -5,11 +5,12 @@ module ActiveRecord
     class BatchEnumerator
       include Enumerable
 
-      def initialize(of: 1000, start: nil, finish: nil, relation:) #:nodoc:
+      def initialize(of: 1000, start: nil, finish: nil, by: primary_key, relation:) #:nodoc:
         @of       = of
         @relation = relation
         @start = start
         @finish = finish
+        @by = by
       end
 
       # The primary key value from which the BatchEnumerator starts, inclusive of the value.
@@ -20,6 +21,9 @@ module ActiveRecord
 
       # The relation from which the BatchEnumerator yields batches.
       attr_reader :relation
+
+      # The key by which the BatchEnumerator iterates.
+      attr_reader :by
 
       # The size of the batches yielded by the BatchEnumerator.
       def batch_size
@@ -90,7 +94,7 @@ module ActiveRecord
       #     relation.update_all(awesome: true)
       #   end
       def each
-        enum = @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: false)
+        enum = @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: false, by: by)
         return enum.each { |relation| yield relation } if block_given?
         enum
       end

--- a/activerecord/test/assets/schema_dump_5_1.yml
+++ b/activerecord/test/assets/schema_dump_5_1.yml
@@ -260,6 +260,7 @@ data_sources:
   mixed_case_monkeys: true
   mixins: true
   movies: true
+  names: true
   notifications: true
   numeric_data: true
   orders: true

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -4,9 +4,10 @@ require "cases/helper"
 require "models/comment"
 require "models/post"
 require "models/subscriber"
+require "models/name"
 
 class EachTest < ActiveRecord::TestCase
-  fixtures :posts, :subscribers
+  fixtures :posts, :subscribers, :names
 
   def setup
     @posts = Post.order("id asc")
@@ -65,6 +66,22 @@ class EachTest < ActiveRecord::TestCase
     assert_queries(6) do
       Post.select("id, title, type").find_each(batch_size: 2) do |post|
         assert_kind_of Post, post
+      end
+    end
+  end
+
+  def test_each_should_raise_if_select_is_set_without_by
+    assert_raise(ActiveModel::MissingAttributeError) do
+      Name.select(:id).find_each(batch_size: 1, by: :initials) { |post|
+        flunk "should not call this block"
+      }
+    end
+  end
+
+  def test_each_should_execute_if_by_is_in_select
+    assert_queries(4) do
+      Name.select("initials, first_name, last_name").find_each(batch_size: 2, by: :initials) do |name|
+        assert_kind_of Name, name
       end
     end
   end
@@ -134,6 +151,24 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  def test_find_in_batches_should_start_from_the_start_option_with_by
+    assert_queries(6) do
+      Name.find_in_batches(batch_size: 1, start: "ac", by: :initials) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Name, batch.first
+      end
+    end
+  end
+
+  def test_find_in_batches_should_end_at_the_finish_option_with_by
+    assert_queries(6) do
+      Name.find_in_batches(batch_size: 1, finish: "ca", by: :initials) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Name, batch.first
+      end
+    end
+  end
+
   def test_find_in_batches_shouldnt_execute_query_unless_needed
     assert_queries(2) do
       Post.find_in_batches(batch_size: @total) { |batch| assert_kind_of Array, batch }
@@ -167,6 +202,17 @@ class EachTest < ActiveRecord::TestCase
   def test_each_should_raise_if_order_is_invalid
     assert_raise(ArgumentError) do
       Post.select(:title).find_each(batch_size: 1, order: :invalid) { |post|
+        flunk "should not call this block"
+      }
+    end
+  end
+
+  def test_each_should_raise_if_by_is_missing
+    assert_raise(ArgumentError) do
+      Post.select(:title).find_each(batch_size: 1, by: nil) { |post|
+        flunk "should not call this block"
+      }
+      Post.select(:title).find_each(batch_size: 1, by: "") { |post|
         flunk "should not call this block"
       }
     end
@@ -265,6 +311,27 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  def test_find_in_batches_should_use_supplied_column_as_iteration_key
+    initials_order_names = Name.order("initials asc")
+    start_initials = initials_order_names.second.initials
+
+    names = []
+    Name.find_in_batches(batch_size: 1, start: start_initials, by: :initials) do |batch|
+      names.concat(batch)
+    end
+
+    assert_equal initials_order_names[1..-1].map(&:initials), names.map(&:initials)
+  end
+
+  def test_find_in_batches_should_use_supplied_column_as_iteration_key_when_start_is_not_specified
+    assert_queries(Name.count + 1) do
+      Name.find_in_batches(batch_size: 1, by: :initials) do |batch|
+        assert_kind_of Array, batch
+        assert_kind_of Name, batch.first
+      end
+    end
+  end
+
   def test_find_in_batches_should_return_an_enumerator
     enum = nil
     assert_no_queries do
@@ -299,6 +366,7 @@ class EachTest < ActiveRecord::TestCase
 
     assert_equal limit, total
   end
+
 
   def test_in_batches_should_not_execute_any_query
     assert_no_queries do
@@ -521,6 +589,27 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  def test_in_batches_should_use_supplied_column_as_iteration_key
+    initials_order_names = Name.order("initials asc")
+    start_initials = initials_order_names.second.initials
+
+    names = []
+    Name.in_batches(of: 1, start: start_initials, by: :initials) do |relation|
+      names.concat(relation)
+    end
+
+    assert_equal initials_order_names[1..-1].map(&:initials), names.map(&:initials)
+  end
+
+  def test_in_batches_should_use_supplied_column_as_iteration_key_when_start_is_not_specified
+    assert_queries(Name.count + 1) do
+      Name.in_batches(of: 1, load: true, by: :initials) do |relation|
+        assert_kind_of ActiveRecord::Relation, relation
+        assert_kind_of Name, relation.first
+      end
+    end
+  end
+
   def test_in_batches_should_return_an_enumerator
     enum = nil
     assert_no_queries do
@@ -532,6 +621,17 @@ class EachTest < ActiveRecord::TestCase
         assert_kind_of Post, relation.first
       end
     end
+  end
+
+  def test_in_batches_enumerator_should_pass_by_parameter
+    initials_order_names = Name.order("initials asc")
+
+    names = []
+    Name.in_batches(of: 1, by: :initials).each do |batch|
+      names.concat(batch)
+    end
+
+    assert_equal initials_order_names.map(&:initials), names.map(&:initials)
   end
 
   def test_in_batches_relations_should_not_overlap_with_each_other

--- a/activerecord/test/fixtures/names.yml
+++ b/activerecord/test/fixtures/names.yml
@@ -1,0 +1,29 @@
+alice_carol:
+  initials: ac
+  first_name: alice
+  last_name: carol
+
+alice_bob:
+  initials: ab
+  first_name: alice
+  last_name: bob
+
+bob_carol:
+  initials: bc
+  first_name: bob
+  last_name: carol
+
+bob_alice:
+  initials: ba
+  first_name: bob
+  last_name: alice
+
+carol_bob:
+  initials: cb
+  first_name: carol
+  last_name: bob
+
+carol_alice:
+  initials: ca
+  first_name: carol
+  last_name: alice

--- a/activerecord/test/models/name.rb
+++ b/activerecord/test/models/name.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Name < ActiveRecord::Base
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1263,6 +1263,14 @@ ActiveRecord::Schema.define do
     t.integer :id
     t.datetime :created_at
   end
+
+  create_table :names, force: true do |t|
+    t.string :initials
+    t.string :first_name
+    t.string :last_name
+    t.index :initials, unique: true
+    t.index [:last_name, :first_name], unique: true
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
### Summary

This PR adds iteration for keys other than primary keys. This is useful when records have multiple iterable indexes. One use case might be a table with a GUID primary key that has no meaningful sorting, and a few indexes that are used to generate different types of reports.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Example

```
names = []
Name.in_batches(of: 1, start: start_initials, by: :initials) do |relation|
  names.concat(relation)
end
```

### Possible Variants

This introduces a foot gun for people who would attempt to use non-unique indexes. If there is a way to warn against this, it would likely be valuable. I'm not aware of a way to do this - it may be best to rely on documentation to warn users. 

One way to protect users would be to automatically add the primary key to the end of the iteration key pattern (thus using keyset pagination across a composite key of `non_unique_key, id`. This isn't possible with this PR, but the next PR based on this one adds composite key support. Even though this _is_ possible, from a "big data" perspective it might still be perfomance or space prohibitive to add the id to the index. This is true for my use case (my company hosts a 25TB database), and could be true for other power users for whom this feature is attractive.

The _by_ syntax isn't particularly attractive. It might be better to enhance the _order_ parameter to match the `ORDER  BY` method on relations. This is actually a route I'd like to go down if the community agrees, but I'd want some input here on what the user experience with the API should look like.

### Other Information

This PR is based on: 
https://github.com/montokapro/rails/pull/3 - Efficient yielded batches

This code change lays the ground work for a subsequent PR:
https://github.com/montokapro/rails/pull/1 -  Composite keys in batches

The PR is meant to stand alone, regardless of whether the downstream PRs are accepted.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
