### PR TITLE
Return unordered yielded relations

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -221,9 +221,7 @@ module ActiveRecord
         batch_limit = remaining if remaining < batch_limit
       end
 
-      relation = relation.reorder(batch_order(order))
-
-      limit_relation = relation.limit(batch_limit)
+      limit_relation = relation.reorder(batch_order(order)).limit(batch_limit)
       limit_relation = apply_finish_limit(limit_relation, finish, order) if finish
       limit_relation.skip_query_cache! # Retaining the results in the query cache would undermine the point of batching
 

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -419,6 +419,16 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  def test_in_batches_should_retain_original_order
+    Post.in_batches(of: 1) do |relation|
+      assert_equal relation.except(:order).to_sql, relation.to_sql
+    end
+
+    Post.order("id DESC").in_batches(of: 1) do |relation|
+      assert_equal relation.reorder("id DESC").to_sql, relation.to_sql
+    end
+  end
+
   def test_in_batches_should_start_from_the_start_option
     post = Post.order("id ASC").where("id >= ?", 2).first
     assert_queries(2) do


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

It turns out that returning unordered yielded relations is more efficient for `update_all` and `delete_all` calls, because they avoid subqueries. This also could have been done with an `except(:order)` call of course. However, this maintains the current rails behavior, and works better when a primary key is inefficient or does not exist.

### Other Information

I've since removed the guarantee that records are now processed in order from yielded relations, and instead guarantee the order on the original relation is used. This makes `delete_all` and `update_all` calls from yielded relations more efficient because they can avoid subqueries, and retains the characteristics of the current active record behavior. 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
