### PR TITLE
Pass order in batches

### DIFF
--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -204,7 +204,7 @@ module ActiveRecord
     def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc)
       relation = self
       unless block_given?
-        return BatchEnumerator.new(of: of, start: start, finish: finish, relation: self)
+        return BatchEnumerator.new(of: of, start: start, finish: finish, order: order, relation: self)
       end
 
       unless [:asc, :desc].include?(order)

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -5,11 +5,12 @@ module ActiveRecord
     class BatchEnumerator
       include Enumerable
 
-      def initialize(of: 1000, start: nil, finish: nil, relation:) # :nodoc:
-        @of       = of
+      def initialize(of: 1000, start: nil, finish: nil, order: :asc, relation:) # :nodoc:
+        @of = of
         @relation = relation
         @start = start
         @finish = finish
+        @order = order
       end
 
       # The primary key value from which the BatchEnumerator starts, inclusive of the value.
@@ -17,6 +18,9 @@ module ActiveRecord
 
       # The primary key value at which the BatchEnumerator ends, inclusive of the value.
       attr_reader :finish
+
+      # The primary key order of the BatchEnumerator (can be :asc or :desc). Defaults to :asc.
+      attr_reader :order
 
       # The relation from which the BatchEnumerator yields batches.
       attr_reader :relation
@@ -50,7 +54,7 @@ module ActiveRecord
       def each_record(&block)
         return to_enum(:each_record) unless block_given?
 
-        @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: true).each do |relation|
+        @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, order: @order, load: true).each do |relation|
           relation.records.each(&block)
         end
       end
@@ -90,7 +94,7 @@ module ActiveRecord
       #     relation.update_all(awesome: true)
       #   end
       def each(&block)
-        enum = @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, load: false)
+        enum = @relation.to_enum(:in_batches, of: @of, start: @start, finish: @finish, order: @order, load: false)
         return enum.each(&block) if block_given?
         enum
       end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -349,9 +349,9 @@ class EachTest < ActiveRecord::TestCase
   end
 
   def test_in_batches_each_record_should_be_ordered_by_id
-    ids = Post.order("id ASC").pluck(:id)
+    ids = Post.order("id DESC").pluck(:id)
     assert_queries(6) do
-      Post.in_batches(of: 2).each_record.with_index do |post, i|
+      Post.in_batches(of: 2, order: :desc).each_record.with_index do |post, i|
         assert_equal ids[i], post.id
       end
     end


### PR DESCRIPTION
### Summary

This fixes a bug where the `BatchEnumerator` would not pass the order to `each` and `each_record` when necessary, unlike other relevant parameters.
